### PR TITLE
requirements: added missing pymongo requirement

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -11,4 +11,5 @@ pytest-subtests
 coverage
 func_timeout
 progressbar2
+pymongo
 tqdm


### PR DESCRIPTION
If you `pip install -r src/requirements.txt` in a new virtual env and run `src/aot.py` you get an error:

```
ModuleNotFoundError: No module named 'bson'
```

Adding `pymongo` to `requirements.txt` fixes this.